### PR TITLE
Bugfix: counter had wrong initial value

### DIFF
--- a/ftplugin/html_autoclosetag.vim
+++ b/ftplugin/html_autoclosetag.vim
@@ -35,7 +35,7 @@ endf
 fun s:CountInPage(needle)
 	let pos = [line('.'), col('.')]
 	call cursor(1, 1)
-	let counter = search(a:needle, 'Wc')
+	let counter = 0
 	while search(a:needle, 'W')
 		if !s:InComment() | let counter += 1 | endif
 	endw


### PR DESCRIPTION
search() returns line numbers, so counter's initial value was the first line number that had the tag.
The following HTML for example resulted in a wrong counter value, and so plugin didn't work well:
<!DOCTYPE html>
<html>
    <head>
        <meta charset="utf-8" />
        <title>a</title>
    </head>
    <body>
  <span>

  </span>

  <span>
    </body>
</html>
