### PR TITLE
bug fix for <h#> tag

### DIFF
--- a/ftplugin/html_autoclosetag.vim
+++ b/ftplugin/html_autoclosetag.vim
@@ -17,7 +17,7 @@ let s:did_auto_closetag = 1
 " Gets the current HTML tag by the cursor.
 fun s:GetCurrentTag()
 	return matchstr(matchstr(getline('.'),
-						\ '<\zs\(\w\|=\| \|''\|"\)*>\%'.col('.').'c'), '^\a*')
+						\ '<\zs\(\w\|=\| \|''\|"\)*>\%'.col('.').'c'), '^\w*')
 endf
 
 " Cleanly return after autocompleting an html/xml tag.


### PR DESCRIPTION
```
Thank you for your nice plugin!
I just add some fix for like <h1> tag.
If I typed <h1> it was just add </h> tag.
So I fixed it.
```
